### PR TITLE
export the debug logging facility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: go
 sudo: false
 
 go:
-- 1.4.3
-- 1.5.1
+- 1.6
+- 1.7
+- 1.8
 
 script:
-- go get golang.org/x/tools/cmd/vet
 - go vet ./...
 - go test -v ./...

--- a/README.md
+++ b/README.md
@@ -50,3 +50,11 @@ func main() {
 	}
 }
 ```
+
+The package includes optional debug logging that can be enabled per context:
+
+```
+if os.Getenv("DEBUG") == "1" {
+    ctx.Logger = log.Printf //or any other function with the same signature
+}
+```

--- a/policy_test.go
+++ b/policy_test.go
@@ -20,6 +20,7 @@ func TestRules(t *testing.T) {
 			"some_number":    "1",
 			"some_bool":      "True",
 		},
+		Logger: t.Logf,
 	}
 
 	testCases := []struct {
@@ -78,6 +79,7 @@ func TestPolicy(t *testing.T) {
 		Auth: map[string]string{
 			"domain_id": "admin_domain_id",
 		},
+		Logger: t.Logf,
 	}
 	userContext := Context{
 		Roles: []string{"member"},
@@ -87,6 +89,7 @@ func TestPolicy(t *testing.T) {
 		Request: map[string]string{
 			"user_id": "u-1",
 		},
+		Logger: t.Logf,
 	}
 
 	enforcer, err := NewEnforcer(keystonePolicy)


### PR DESCRIPTION
There's already a nice amount of debug logging in this module, which I could use to test its behavior while integrating it into [Limes](https://github.com/sapcc/limes), and to validate new policies more easily. But it's all private and there's no way to enable it!

This PR extends the `Context` struct such that I can plug my own logging facility into it if I wish to.