### PR TITLE
add Context.LookupRequestValue

### DIFF
--- a/policy_test.go
+++ b/policy_test.go
@@ -16,9 +16,15 @@ func TestRules(t *testing.T) {
 		},
 		Request: map[string]string{
 			"target.user_id": "u-1",
-			"user_id":        "u-2",
 			"some_number":    "1",
 			"some_bool":      "True",
+		},
+		LookupRequestValue: func(name string) string {
+			if name == "user_id" {
+				return "u-2"
+			} else {
+				return ""
+			}
 		},
 		Logger: t.Logf,
 	}


### PR DESCRIPTION
It is a common usecase for us to pull request values out of the request path match in the HTTP router. With gorilla/mux, this works fine because mux.Vars(r) gives a map[string]string, i.e. just what goslo.policy wants.

But the new HTTP router functionality in the standard library does not have that: You can only query for one path value at a time. This PR adds API to make an integration with the net/http router possible.